### PR TITLE
Bump alpine to 3.14 to resolve critical vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.14
 RUN apk --no-cache add ca-certificates
 COPY kube-tasks /usr/local/bin/kube-tasks
 RUN addgroup -g 1001 -S kube-tasks \


### PR DESCRIPTION
Signed-off-by: bondbenbond 

Resolves critical vulnerabilities in your `0.2.0` image in Dockerhub

Image | CVE | Package | Version | Severity | Status
--|--|--|--|--|--
sha256:63d61fbfb71273dfb15b51540db42afac19335478536496d7079d7031cd09292 | CVE-2018-1000517 | busybox | 1.28.4-r3 | critical | fixed in 1.29.3-r10
sha256:63d61fbfb71273dfb15b51540db42afac19335478536496d7079d7031cd09292 | CVE-2019-14697 | musl | 1.1.19-r10 | critical | fixed in 1.1.19-r11: unknown