### PR TITLE
Added flag to skip file errors during copy

### DIFF
--- a/cmd/kube-tasks.go
+++ b/cmd/kube-tasks.go
@@ -37,14 +37,15 @@ func NewRootCmd(args []string) *cobra.Command {
 }
 
 type simpleBackupCmd struct {
-	namespace  string
-	selector   string
-	container  string
-	path       string
-	dst        string
-	parallel   int
-	tag        string
-	bufferSize float64
+	namespace      string
+	selector       string
+	container      string
+	path           string
+	dst            string
+	parallel       int
+	tag            string
+	bufferSize     float64
+	skipErrorFiles bool
 
 	out io.Writer
 }
@@ -58,7 +59,7 @@ func NewSimpleBackupCmd(out io.Writer) *cobra.Command {
 		Short: "Backup files to cloud storage",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			if _, err := kubetasks.SimpleBackup(b.namespace, b.selector, b.container, b.path, b.dst, b.parallel, b.tag, b.bufferSize); err != nil {
+			if _, err := kubetasks.SimpleBackup(b.namespace, b.selector, b.container, b.path, b.dst, b.parallel, b.tag, b.bufferSize, b.skipErrorFiles); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/pkg/kubetasks/kubetasks.go
+++ b/pkg/kubetasks/kubetasks.go
@@ -13,7 +13,7 @@ import (
 )
 
 // SimpleBackup performs backup
-func SimpleBackup(namespace, selector, container, path, dst string, parallel int, tag string, bufferSize float64) (string, error) {
+func SimpleBackup(namespace, selector, container, path, dst string, parallel int, tag string, bufferSize float64, skipErrorFiles bool) (string, error) {
 	log.Println("Backup started!")
 	dstPrefix, dstPath := utils.SplitInTwo(dst, "://")
 	dstPath = filepath.Join(dstPath, tag)
@@ -41,7 +41,7 @@ func SimpleBackup(namespace, selector, container, path, dst string, parallel int
 	}
 
 	log.Println("Starting files copy to tag: " + tag)
-	if err := skbn.PerformCopy(k8sClient, dstClient, "k8s", dstPrefix, fromToPathsAllPods, parallel, bufferSize); err != nil {
+	if err := skbn.PerformCopy(k8sClient, dstClient, "k8s", dstPrefix, fromToPathsAllPods, parallel, bufferSize, skipErrorFiles); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
So in case an error occurs for one file, the file is skipped. The behavior is triggered via the method parameter skipErrorFiles.
If the parameter is set to false the behaviour is the same as before.

I have never coded go but this fix allowed me to skip files that got deleted during the backup run.
If there are better ways feel free to adjust or comment.

NOTE:
This PR can only be merged after this PR got merged: https://github.com/maorfr/skbn/pull/23

Signed-off-by: lhgloj1 <jannic.lollert@liebherr.com>